### PR TITLE
groupsテーブルの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,46 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|integer|null: false, foreign_key: true|
+|password|||
+|email|
+
+
+### Association
+belongs_to :groups
+belongs_to :groups_users
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|integer|null: false, foreign_key: true|
+
+
+### Association
+belongs_to :users
+belongs_to :groups_users
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|text|integer|null: false, foreign_key: true|
+|image|integer|null: false, foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+


### PR DESCRIPTION
#What
groupsテーブルを実装する。READMEにgroup-nameカラムを追加した。

#Why
新規にグループを作成する場合、グループ名が必要なため。

|Column|Type|Options|
|------|----|-------|
|group_name|integer|null: false, foreign_key: true|